### PR TITLE
feat: add allowedPaths option to cwdOnly guard

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -84,6 +84,7 @@ export const DEFAULT_CONFIG: MoonpiConfig = {
   },
   guards: {
     cwdOnly: true,
+    allowedPaths: [],
     readBeforeWrite: true,
   },
   keybindings: {
@@ -152,6 +153,7 @@ function mergeConfig(base: MoonpiConfig, raw: Record<string, unknown> | undefine
 
   if (isRecord(raw.guards)) {
     if (typeof raw.guards.cwdOnly === "boolean") next.guards.cwdOnly = raw.guards.cwdOnly;
+    next.guards.allowedPaths = readStringArray(raw.guards.allowedPaths, next.guards.allowedPaths);
     if (typeof raw.guards.readBeforeWrite === "boolean") {
       next.guards.readBeforeWrite = raw.guards.readBeforeWrite;
     }

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -20,11 +20,24 @@ function normalizePath(filePath: string, cwd: string): string {
   return existsSync(absolute) ? realpathSync(absolute) : absolute;
 }
 
-function isInsideCwd(filePath: string, cwd: string): boolean {
-  const cwdReal = existsSync(cwd) ? realpathSync(cwd) : resolve(cwd);
-  const target = normalizePath(filePath, cwdReal);
-  const rel = relative(cwdReal, target);
+function isInsideDir(filePath: string, dir: string): boolean {
+  const dirReal = existsSync(dir) ? realpathSync(dir) : resolve(dir);
+  const target = normalizePath(filePath, dirReal);
+  const rel = relative(dirReal, target);
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function isInsideCwd(filePath: string, cwd: string): boolean {
+  return isInsideDir(filePath, cwd);
+}
+
+function isInAllowedPath(filePath: string, cwd: string, allowedPaths: string[]): boolean {
+  for (const allowed of allowedPaths) {
+    const expanded = expandPath(allowed);
+    const absolute = isAbsolute(expanded) ? resolve(expanded) : resolve(cwd, expanded);
+    if (isInsideDir(filePath, absolute)) return true;
+  }
+  return false;
 }
 
 function pathFromToolCall(event: ToolCallEvent): string | undefined {
@@ -47,10 +60,10 @@ export function installGuards(pi: ExtensionAPI, controller: MoonpiController): v
     if (!shouldCheckPath(event.toolName)) return undefined;
     const rawPath = pathFromToolCall(event) ?? ".";
 
-    if (controller.config.guards.cwdOnly && !isInsideCwd(rawPath, ctx.cwd)) {
+    if (controller.config.guards.cwdOnly && !isInsideCwd(rawPath, ctx.cwd) && !isInAllowedPath(rawPath, ctx.cwd, controller.config.guards.allowedPaths)) {
       return {
         block: true,
-        reason: `moonpi blocked ${event.toolName}: path is outside the current working directory: ${rawPath}`,
+        reason: `moonpi blocked ${event.toolName}: path is outside the current working directory and allowed paths: ${rawPath}`,
       };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface MoonpiConfig {
   };
   guards: {
     cwdOnly: boolean;
+    allowedPaths: string[];
     readBeforeWrite: boolean;
   };
   keybindings: {


### PR DESCRIPTION
## Summary

- Adds `guards.allowedPaths` option — an array of directories that are permitted for reads even when `cwdOnly` is enabled
- Solves the problem described in #1: the agent can't read its own documentation or extension docs because they live outside the project directory

## Changes

- `types.ts`: Add `allowedPaths: string[]` to guards config interface
- `config.ts`: Default to empty array, merge via existing `readStringArray()` helper
- `guards.ts`: Extract `isInsideDir()` from `isInsideCwd()`, add `isInAllowedPath()` check before blocking

## Backward compatible

Default is `[]`, so existing configs behave identically.

## Usage

```json
{
  "guards": {
    "allowedPaths": [
      "/opt/homebrew/Cellar/pi-coding-agent",
      "~/.pi/agent"
    ]
  }
}
```

Paths support `~` expansion and relative paths (resolved from cwd). Works in both global (`~/.pi/agent/moonpi.json`) and project-level (`.pi/moonpi.json`) configs.

Closes #1
