### PR TITLE
Fix startup lag, editor override, and missing config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ Configure `.pi/moonpi.json` (project) or `~/.pi/agent/moonpi.json` (global):
 
 ```json
 {
+  "defaultMode": "auto",
+  "preserveExternalTools": false,
+  "customEditor": true,
   "contextFiles": {
     "enabled": true,
     "fileNames": ["README.md", "SPECS.md", "SPRINT.md"],
@@ -211,9 +214,28 @@ Configure `.pi/moonpi.json` (project) or `~/.pi/agent/moonpi.json` (global):
     "cwdOnly": true,
     "allowedPaths": ["~/.pi/agent"],
     "readBeforeWrite": true
+  },
+  "keybindings": {
+    "cycleNext": "tab",
+    "cyclePrevious": ""
   }
 }
 ```
+
+#### General
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `defaultMode` | `"auto"` | Mode used at session start. One of `"plan"`, `"act"`, `"auto"`, `"fast"` |
+| `preserveExternalTools` | `false` | When `true`, tools registered by other extensions are kept alongside moonpi tools when applying mode tool restrictions |
+| `customEditor` | `true` | When `false`, moonpi skips installing its mode-colored editor, preserving editor customizations from other extensions |
+
+#### Keybindings
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `cycleNext` | `"tab"` | Keybinding to cycle to the next mode when the editor is empty |
+| `cyclePrevious` | `""` (disabled) | Keybinding to cycle to the previous mode when the editor is empty |
 
 #### Context files
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ export const DEFAULT_PICKABLE_EXTENSIONS = [
 
 export const DEFAULT_CONFIG: MoonpiConfig = {
   defaultMode: "auto",
-  preserveExternalTools: false,
+  preserveExternalTools: true,
   customEditor: true,
   contextFiles: {
     enabled: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ export const DEFAULT_PICKABLE_EXTENSIONS = [
 export const DEFAULT_CONFIG: MoonpiConfig = {
   defaultMode: "auto",
   preserveExternalTools: false,
+  customEditor: true,
   contextFiles: {
     enabled: true,
     fileNames: ["README.md", "SPECS.md", "SPRINT.md"],
@@ -123,6 +124,7 @@ function mergeConfig(base: MoonpiConfig, raw: Record<string, unknown> | undefine
   const next: MoonpiConfig = {
     defaultMode: base.defaultMode,
     preserveExternalTools: base.preserveExternalTools,
+    customEditor: base.customEditor,
     contextFiles: { ...base.contextFiles },
     guards: { ...base.guards },
     keybindings: { ...base.keybindings },
@@ -130,6 +132,7 @@ function mergeConfig(base: MoonpiConfig, raw: Record<string, unknown> | undefine
 
   if (isSelectableMode(raw.defaultMode)) next.defaultMode = raw.defaultMode;
   if (typeof raw.preserveExternalTools === "boolean") next.preserveExternalTools = raw.preserveExternalTools;
+  if (typeof raw.customEditor === "boolean") next.customEditor = raw.customEditor;
 
   if (isRecord(raw.contextFiles)) {
     const context = raw.contextFiles;

--- a/src/modes.ts
+++ b/src/modes.ts
@@ -105,7 +105,9 @@ export class MoonpiController {
 
   installUi(ctx: ExtensionContext): void {
     installMoonpiHeader(ctx);
-    installMoonpiEditor(ctx, () => this.state.mode);
+    if (this.config.customEditor) {
+      installMoonpiEditor(ctx, () => this.state.mode);
+    }
     this.terminalInputUnsubscribe?.();
     this.terminalInputUnsubscribe = ctx.ui.onTerminalInput((data) => {
       if (ctx.ui.getEditorText().length > 0) return undefined;

--- a/src/synthetic.ts
+++ b/src/synthetic.ts
@@ -338,7 +338,9 @@ export async function installSynthetic(pi: ExtensionAPI): Promise<void> {
   // and refresh the model list from the live API.
   pi.on("session_start", async (_event, ctx) => {
     const apiKey = await getSyntheticApiKey(ctx);
-    await refreshLiveModels(pi, apiKey, ctx.signal);
+    // Fire-and-forget: don't block session startup on the network request.
+    // Cached/fallback models are already registered, so the provider is usable immediately.
+    refreshLiveModels(pi, apiKey, ctx.signal).catch(() => {});
   });
 
   pi.registerCommand("synthetic:quotas", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,9 @@ export interface MoonpiSnapshot {
 export interface MoonpiConfig {
   defaultMode: MoonpiMode;
   preserveExternalTools: boolean;
+  /** Whether moonpi installs its custom mode-colored editor. Set to false to preserve
+   *  editor customizations from other extensions (e.g. pi-wierd-statusline). */
+  customEditor: boolean;
   contextFiles: {
     enabled: boolean;
     fileNames: string[];


### PR DESCRIPTION
## Changes

Closes #3

### Bug fixes

- **Startup lag**: `session_start` handler now fire-and-forgets `refreshLiveModels()` instead of awaiting it. The cached/fallback models are already registered, so the ~1.5s HTTP call no longer blocks startup.
- **Editor override**: Moonpi unconditionally called `setEditorComponent()` in `session_start`, overwriting editor customizations from other extensions (e.g. pi-wierd-statusline). Added `customEditor` config option (default `true`) — set to `false` to skip the moonpi editor.
- **External tools stripped**: `preserveExternalTools` defaulted to `false`, silently removing tools registered by other extensions (e.g. pi-context). Changed default to `true`.

### Docs

- Aligned README config section with all configurable options (was missing `defaultMode`, `preserveExternalTools`, `customEditor`, `keybindings`).